### PR TITLE
Record Stripe orders via webhook and confirm on success page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,16 @@ To sync products between Supabase and Stripe:
    - `SUPABASE_SERVICE_ROLE_KEY=service-key`
    - `STRIPE_SECRET_KEY=stripe-secret-key`
 3. Run `npm run sync:stripe` to perform the synchronization.
+
+## Order processing configuration
+
+Successful Stripe checkouts are finalized through the `stripe-webhook` Supabase Edge Function and confirmed on the `/payment-success` page via the `confirm-order` function. Make sure the following environment variables are configured for your Supabase functions runtime:
+
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `RESEND_API_KEY` (only required if you want to send confirmation emails via Resend)
+- `ORDER_FROM_EMAIL` (the verified sender to use with Resend)
+- `SITE_URL` (used for redirect URLs in the checkout flow)
+
+After deploying the functions, point your Stripe webhook to `https://<project-ref>.functions.supabase.co/stripe-webhook` and subscribe to the `checkout.session.completed` event so orders are recorded and receipts are dispatched automatically.

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
 import { Loader2 } from "lucide-react";
+import type { User } from "@supabase/supabase-js";
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -17,7 +18,7 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [user, setUser] = useState<any>(null);
+  const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -168,10 +169,11 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
       toast({ title: "Account Deleted" });
       setUser(null);
       onClose();
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Failed to delete account.";
       toast({
         title: "Error",
-        description: error.message || "Failed to delete account.",
+        description: message,
         variant: "destructive",
       });
     } finally {
@@ -197,7 +199,7 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
             <div className="space-y-4">
               <div className="space-y-2">
                 <Label>Email</Label>
-                <Input value={user.email} disabled />
+                <Input value={user?.email ?? ""} disabled />
               </div>
               {user.user_metadata?.full_name && (
                 <div className="space-y-2">

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -206,6 +206,7 @@ export function useCart() {
       }
 
       const payload = cartItems.map(item => ({
+        product_id: item.product_id,
         stripe_price_id: item.stripe_price_id,
         price: item.price,
         product_name: item.product_name,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -90,28 +90,40 @@ export type Database = {
       }
       orders: {
         Row: {
+          customer_email: string | null
           created_at: string
           id: string
+          receipt_url: string | null
           shipping_address: Json | null
           status: string
+          stripe_payment_intent_id: string | null
+          stripe_session_id: string | null
           total_amount: number
           updated_at: string
           user_id: string | null
         }
         Insert: {
+          customer_email?: string | null
           created_at?: string
           id?: string
+          receipt_url?: string | null
           shipping_address?: Json | null
           status?: string
+          stripe_payment_intent_id?: string | null
+          stripe_session_id?: string | null
           total_amount: number
           updated_at?: string
           user_id?: string | null
         }
         Update: {
+          customer_email?: string | null
           created_at?: string
           id?: string
+          receipt_url?: string | null
           shipping_address?: Json | null
           status?: string
+          stripe_payment_intent_id?: string | null
+          stripe_session_id?: string | null
           total_amount?: number
           updated_at?: string
           user_id?: string | null

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -1,12 +1,141 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams, Link } from "react-router-dom";
-import { CheckCircle, ArrowLeft, Package } from "lucide-react";
+import { CheckCircle, ArrowLeft, Package, Loader2, AlertCircle, Receipt } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { supabase } from "@/integrations/supabase/client";
+import { useCart } from "@/hooks/useCart";
+
+type OrderItem = {
+  id: string;
+  product_id: string;
+  product_name: string;
+  quantity: number;
+  price: number;
+};
+
+type OrderSummary = {
+  id: string;
+  created_at: string;
+  total_amount: number;
+  status: string;
+  receipt_url: string | null;
+  items: OrderItem[];
+};
+
+type OrderItemResponse = {
+  id: string;
+  product_id: string;
+  product_name?: string | null;
+  quantity: number;
+  price: number | string | null;
+};
+
+type ConfirmOrderResponse = {
+  id: string;
+  created_at: string;
+  total_amount: number | string | null;
+  status: string;
+  receipt_url?: string | null;
+  items?: OrderItemResponse[];
+};
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
 
 export default function PaymentSuccess() {
   const [searchParams] = useSearchParams();
-  const sessionId = searchParams.get('session_id');
+  const sessionId = searchParams.get("session_id");
+  const { clearCart } = useCart();
+  const clearCartRef = useRef(clearCart);
+  const [order, setOrder] = useState<OrderSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    clearCartRef.current = clearCart;
+  }, [clearCart]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function confirmOrder() {
+      if (!sessionId) {
+        setError("Missing payment reference.");
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+
+      try {
+        const { data, error: fnError } = await supabase.functions.invoke("confirm-order", {
+          body: { sessionId },
+        });
+
+        if (fnError)
+          throw new Error(fnError.message ?? "Unable to confirm payment");
+
+        const responseOrder = (data as { order?: ConfirmOrderResponse } | null)?.order;
+        if (!responseOrder)
+          throw new Error("Order not found");
+
+        const mapped: OrderSummary = {
+          id: responseOrder.id,
+          created_at: responseOrder.created_at,
+          total_amount: Number(responseOrder.total_amount ?? 0),
+          status: responseOrder.status,
+          receipt_url: responseOrder.receipt_url ?? null,
+          items: (responseOrder.items ?? []).map((item: OrderItemResponse) => ({
+            id: item.id,
+            product_id: item.product_id,
+            product_name: item.product_name || "Electronic kit",
+            quantity: item.quantity,
+            price: Number(item.price ?? 0),
+          })),
+        };
+
+        if (!isActive)
+          return;
+
+        setOrder(mapped);
+        setError(null);
+        setLoading(false);
+
+        try {
+          await clearCartRef.current?.();
+        } catch (cartError) {
+          console.error("Failed to clear cart after purchase", cartError);
+        }
+      } catch (err) {
+        console.error("Failed to confirm order", err);
+        if (!isActive)
+          return;
+
+        setOrder(null);
+        setError(err instanceof Error ? err.message : "Failed to confirm payment");
+        setLoading(false);
+      }
+    }
+
+    confirmOrder();
+
+    return () => {
+      isActive = false;
+    };
+  }, [sessionId]);
+
+  const formattedDate = useMemo(() => {
+    if (!order?.created_at)
+      return null;
+    try {
+      return new Date(order.created_at).toLocaleString();
+    } catch {
+      return order.created_at;
+    }
+  }, [order?.created_at]);
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
@@ -19,24 +148,97 @@ export default function PaymentSuccess() {
         </CardHeader>
         
         <CardContent className="space-y-4">
-          <p className="text-muted-foreground">
-            Thank you for your purchase! Your electronic kits are being prepared for shipment.
-          </p>
-          
-          <div className="bg-muted/50 p-4 rounded-lg">
-            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Package className="w-4 h-4" />
-              <span>Order confirmation will be sent to your email</span>
+          {loading && (
+            <div className="flex flex-col items-center gap-3 text-muted-foreground py-6">
+              <Loader2 className="w-6 h-6 animate-spin" />
+              <p>Confirming your order...</p>
             </div>
-          </div>
+          )}
+
+          {!loading && error && (
+            <div className="space-y-3">
+              <div className="bg-destructive/10 text-destructive rounded-lg p-4 flex items-center gap-3 text-left">
+                <AlertCircle className="w-5 h-5" />
+                <div>
+                  <p className="font-semibold">We couldn&apos;t confirm your order</p>
+                  <p className="text-sm text-destructive/80">{error}</p>
+                </div>
+              </div>
+
+              <p className="text-sm text-muted-foreground">
+                If you were charged, our support team will have the record.
+                Please contact us with your payment reference so we can help you out.
+              </p>
+            </div>
+          )}
+
+          {!loading && !error && order && (
+            <div className="space-y-4 text-left">
+              <div className="bg-muted/50 p-4 rounded-lg">
+                <div className="flex items-start gap-3">
+                  <Package className="w-5 h-5 mt-0.5 text-circuit-green" />
+                  <div className="space-y-1">
+                    <p className="font-semibold text-foreground">Order #{order.id.slice(0, 8)}</p>
+                    {formattedDate && (
+                      <p className="text-sm text-muted-foreground">Placed on {formattedDate}</p>
+                    )}
+                    <p className="text-sm text-muted-foreground">
+                      We&apos;ve emailed your receipt and will let you know when your kits ship.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                {order.items.length === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    Your payment was successful, but we couldn&apos;t load the line items. A detailed receipt has been emailed to you.
+                  </p>
+                )}
+
+                {order.items.map((item) => (
+                  <div key={item.id} className="flex items-start justify-between gap-4 text-sm">
+                    <div>
+                      <p className="font-medium text-foreground">{item.product_name}</p>
+                      <p className="text-muted-foreground">Qty {item.quantity}</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-medium text-foreground">
+                        {currencyFormatter.format(item.price * item.quantity)}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {currencyFormatter.format(item.price)} each
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex items-center justify-between border-t pt-3 text-sm">
+                <span className="font-semibold text-foreground">Order total</span>
+                <span className="font-semibold text-foreground">
+                  {currencyFormatter.format(order.total_amount)}
+                </span>
+              </div>
+
+              {order.receipt_url && (
+                <Button variant="outline" asChild className="w-full">
+                  <a href={order.receipt_url} target="_blank" rel="noreferrer">
+                    <Receipt className="w-4 h-4 mr-2" />
+                    View Stripe receipt
+                  </a>
+                </Button>
+              )}
+            </div>
+          )}
 
           {sessionId && (
             <p className="text-xs text-muted-foreground">
-              Reference: {sessionId.slice(-8)}
+              Payment reference: {sessionId.slice(-8)}
             </p>
           )}
-          
-          <div className="pt-4">
+
+          <div className="pt-2">
             <Button asChild className="w-full">
               <Link to="/">
                 <ArrowLeft className="w-4 h-4 mr-2" />

--- a/supabase/functions/confirm-order/index.ts
+++ b/supabase/functions/confirm-order/index.ts
@@ -1,0 +1,106 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+serve(async (req) => {
+  if (req.method === "OPTIONS")
+    return new Response(null, { headers: corsHeaders });
+
+  if (req.method !== "POST")
+    return json({ error: "Method not allowed" }, 405);
+
+  if (!SUPABASE_URL || !ANON_KEY || !SERVICE_ROLE_KEY)
+    return json({ error: "Supabase configuration missing" }, 500);
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader)
+    return json({ error: "Missing bearer token" }, 401);
+
+  const token = authHeader.replace("Bearer ", "");
+  const supabase = createClient(SUPABASE_URL, ANON_KEY);
+  const { data: { user }, error: userError } = await supabase.auth.getUser(token);
+
+  if (userError || !user)
+    return json({ error: "Invalid or expired token" }, 401);
+
+  let body: { sessionId?: string; session_id?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const sessionId = body.sessionId ?? body.session_id;
+  if (!sessionId)
+    return json({ error: "Missing session_id" }, 400);
+
+  const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+  const { data: order, error: orderError } = await admin
+    .from("orders")
+    .select(`
+      id,
+      user_id,
+      created_at,
+      total_amount,
+      status,
+      receipt_url,
+      shipping_address,
+      customer_email,
+      stripe_session_id,
+      order_items (
+        id,
+        product_id,
+        quantity,
+        price,
+        products (name, image_url)
+      )
+    `)
+    .eq("stripe_session_id", sessionId)
+    .maybeSingle();
+
+  if (orderError)
+    return json({ error: orderError.message }, 500);
+
+  if (!order)
+    return json({ error: "Order not found" }, 404);
+
+  if (order.user_id && order.user_id !== user.id)
+    return json({ error: "Forbidden" }, 403);
+
+  const items = (order.order_items ?? []).map((item) => ({
+    id: item.id,
+    product_id: item.product_id,
+    quantity: item.quantity,
+    price: item.price,
+    product_name: item.products?.name ?? "",
+    image_url: item.products?.image_url ?? null,
+  }));
+
+  return json({
+    order: {
+      id: order.id,
+      created_at: order.created_at,
+      total_amount: order.total_amount,
+      status: order.status,
+      receipt_url: order.receipt_url,
+      shipping_address: order.shipping_address,
+      customer_email: order.customer_email,
+      items,
+    },
+  });
+});
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,367 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import Stripe from "https://esm.sh/stripe@14.21.0";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, stripe-signature",
+};
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const STRIPE_SECRET_KEY = Deno.env.get("STRIPE_SECRET_KEY") ?? "";
+const STRIPE_WEBHOOK_SECRET = Deno.env.get("STRIPE_WEBHOOK_SECRET") ?? "";
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") ?? "";
+const ORDER_FROM_EMAIL = Deno.env.get("ORDER_FROM_EMAIL") ?? "";
+
+const supabaseAdmin = (SUPABASE_URL && SERVICE_ROLE_KEY)
+  ? createClient(SUPABASE_URL, SERVICE_ROLE_KEY)
+  : null;
+
+const stripe = STRIPE_SECRET_KEY
+  ? new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2023-10-16" })
+  : null;
+
+type CartMetadataItem = {
+  product_id: string;
+  quantity: number;
+  price_cents: number;
+  name?: string;
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS")
+    return new Response(null, { headers: corsHeaders });
+
+  if (!stripe || !STRIPE_WEBHOOK_SECRET)
+    return json({ error: "Stripe configuration missing" }, 500);
+
+  if (!supabaseAdmin)
+    return json({ error: "Supabase configuration missing" }, 500);
+
+  const signature = req.headers.get("stripe-signature");
+  if (!signature)
+    return json({ error: "Missing stripe signature" }, 400);
+
+  const payload = await req.text();
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(payload, signature, STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    console.error("Stripe signature verification failed", err);
+    return json({ error: "Invalid signature" }, 400);
+  }
+
+  try {
+    if (event.type === "checkout.session.completed") {
+      await handleCheckoutSessionCompleted(event.data.object as Stripe.Checkout.Session);
+    } else {
+      console.log(`Unhandled Stripe event: ${event.type}`);
+    }
+  } catch (err) {
+    console.error(`Failed to process event ${event.id}`, err);
+    return json({ error: "Failed to process webhook" }, 500);
+  }
+
+  return json({ received: true }, 200);
+});
+
+async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) {
+  if (!supabaseAdmin || !stripe)
+    throw new Error("Missing configuration");
+
+  const userId = session.metadata?.user_id;
+  if (!userId) {
+    console.warn(`Checkout session ${session.id} missing user_id metadata`);
+    return;
+  }
+
+  const { data: existingOrder, error: existingError } = await supabaseAdmin
+    .from("orders")
+    .select("id")
+    .eq("stripe_session_id", session.id)
+    .maybeSingle();
+
+  if (existingError) {
+    throw existingError;
+  }
+
+  if (existingOrder) {
+    console.log(`Order ${existingOrder.id} already recorded for session ${session.id}`);
+    return;
+  }
+
+  const cartItems = await buildOrderItems(session);
+
+  const totalCents = typeof session.amount_total === "number"
+    ? session.amount_total
+    : Number(session.metadata?.total_amount_cents ?? 0);
+
+  const paymentIntentId = typeof session.payment_intent === "string"
+    ? session.payment_intent
+    : session.payment_intent?.id ?? null;
+
+  const customerEmail = session.customer_details?.email
+    ?? session.customer_email
+    ?? null;
+
+  const shippingPayload = session.customer_details
+    ? {
+        name: session.customer_details.name,
+        email: customerEmail,
+        phone: session.customer_details.phone,
+        address: session.customer_details.address,
+      }
+    : null;
+
+  const { data: order, error: orderError } = await supabaseAdmin
+    .from("orders")
+    .insert({
+      user_id: userId,
+      total_amount: Number((totalCents / 100).toFixed(2)),
+      status: "processing",
+      shipping_address: shippingPayload,
+      stripe_session_id: session.id,
+      stripe_payment_intent_id: paymentIntentId,
+      receipt_url: null,
+      customer_email: customerEmail,
+    })
+    .select("id, created_at, total_amount")
+    .single();
+
+  if (orderError || !order)
+    throw orderError ?? new Error("Failed to create order record");
+
+  const orderItemsPayload = cartItems
+    .filter((item) => item.product_id)
+    .map((item) => ({
+      order_id: order.id,
+      product_id: item.product_id,
+      quantity: item.quantity,
+      price: Number((item.price_cents / 100).toFixed(2)),
+    }));
+
+  if (orderItemsPayload.length > 0) {
+    const { error: orderItemsError } = await supabaseAdmin
+      .from("order_items")
+      .insert(orderItemsPayload);
+
+    if (orderItemsError)
+      throw orderItemsError;
+  }
+
+  const { error: clearCartError } = await supabaseAdmin
+    .from("cart_items")
+    .delete()
+    .eq("user_id", userId);
+
+  if (clearCartError)
+    console.error(`Failed to clear cart for user ${userId}`, clearCartError);
+
+  let receiptUrl: string | null = null;
+  if (paymentIntentId) {
+    try {
+      const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId, { expand: ["charges"] });
+      const metadataUpdate = { ...paymentIntent.metadata, order_id: order.id };
+      const updatePayload: Stripe.PaymentIntentUpdateParams = { metadata: metadataUpdate };
+
+      if (customerEmail && paymentIntent.receipt_email !== customerEmail)
+        updatePayload.receipt_email = customerEmail;
+
+      await stripe.paymentIntents.update(paymentIntent.id, updatePayload);
+
+      const charge = paymentIntent.charges?.data?.[0];
+      if (charge?.receipt_url) {
+        receiptUrl = charge.receipt_url;
+      } else if (typeof paymentIntent.latest_charge === "string") {
+        try {
+          const latestCharge = await stripe.charges.retrieve(paymentIntent.latest_charge);
+          receiptUrl = latestCharge.receipt_url ?? null;
+        } catch (chargeError) {
+          console.error("Failed to retrieve latest charge", chargeError);
+        }
+      }
+    } catch (intentError) {
+      console.error("Failed to process payment intent", intentError);
+    }
+  }
+
+  const { error: updateOrderError } = await supabaseAdmin
+    .from("orders")
+    .update({
+      receipt_url: receiptUrl,
+      customer_email: customerEmail,
+    })
+    .eq("id", order.id);
+
+  if (updateOrderError)
+    console.error("Failed to update order with receipt information", updateOrderError);
+
+  if (customerEmail)
+    await sendConfirmationEmail({
+      to: customerEmail,
+      orderId: order.id,
+      createdAt: order.created_at,
+      totalCents,
+      receiptUrl,
+      items: cartItems,
+    });
+}
+
+async function buildOrderItems(session: Stripe.Checkout.Session): Promise<CartMetadataItem[]> {
+  if (!stripe)
+    return [];
+
+  const metadataItems = parseCartMetadata(session.metadata?.cart);
+
+  const lineItems = await stripe.checkout.sessions.listLineItems(session.id, { limit: 100 });
+  const combined: CartMetadataItem[] = [];
+
+  for (let i = 0; i < lineItems.data.length; i++) {
+    const line = lineItems.data[i];
+    const metadata = metadataItems[i];
+
+    const quantity = line.quantity ?? metadata?.quantity ?? 1;
+    const amountSubtotal = typeof line.amount_subtotal === "number"
+      ? line.amount_subtotal
+      : (metadata?.price_cents ?? 0) * quantity;
+    const unitAmount = quantity > 0 ? amountSubtotal / quantity : metadata?.price_cents ?? 0;
+
+    combined.push({
+      product_id: metadata?.product_id ?? "",
+      quantity,
+      price_cents: Math.round(unitAmount),
+      name: metadata?.name ?? line.description ?? undefined,
+    });
+  }
+
+  return combined;
+}
+
+function parseCartMetadata(raw: string | null | undefined): CartMetadataItem[] {
+  if (!raw)
+    return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed))
+      return [];
+
+    return parsed
+      .filter((item) => item && typeof item.p === "string")
+      .map((item) => ({
+        product_id: item.p as string,
+        quantity: typeof item.q === "number" ? item.q : Number(item.q) || 1,
+        price_cents: typeof item.pr === "number" ? item.pr : Number(item.pr) || 0,
+        name: typeof item.n === "string" ? item.n : undefined,
+      }));
+  } catch (error) {
+    console.error("Failed to parse cart metadata", error);
+    return [];
+  }
+}
+
+async function sendConfirmationEmail(params: {
+  to: string;
+  orderId: string;
+  createdAt: string;
+  totalCents: number;
+  receiptUrl: string | null;
+  items: CartMetadataItem[];
+}) {
+  const { to, orderId, createdAt, totalCents, receiptUrl, items } = params;
+
+  if (!RESEND_API_KEY || !ORDER_FROM_EMAIL) {
+    console.warn("Email configuration missing; skipping confirmation email");
+    return;
+  }
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  });
+
+  const itemsHtml = items
+    .map((item) => `
+      <tr>
+        <td style="padding: 4px 8px; border: 1px solid #e5e7eb;">${escapeHtml(item.name ?? "Item")}</td>
+        <td style="padding: 4px 8px; border: 1px solid #e5e7eb; text-align: center;">${item.quantity}</td>
+        <td style="padding: 4px 8px; border: 1px solid #e5e7eb; text-align: right;">${currencyFormatter.format((item.price_cents * item.quantity) / 100)}</td>
+      </tr>
+    `)
+    .join("");
+
+  const totalFormatted = currencyFormatter.format(totalCents / 100);
+  const receiptLink = receiptUrl
+    ? `<p>You can download your Stripe receipt <a href="${receiptUrl}">here</a>.</p>`
+    : "";
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #111827;">
+      <h2 style="color: #047857;">Thank you for your order!</h2>
+      <p>Order ID: <strong>${orderId}</strong></p>
+      <p>Order date: ${new Date(createdAt).toLocaleString()}</p>
+      <table style="border-collapse: collapse; width: 100%; margin-top: 16px;">
+        <thead>
+          <tr>
+            <th style="padding: 6px 8px; border: 1px solid #e5e7eb; text-align: left;">Item</th>
+            <th style="padding: 6px 8px; border: 1px solid #e5e7eb;">Qty</th>
+            <th style="padding: 6px 8px; border: 1px solid #e5e7eb; text-align: right;">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${itemsHtml}
+        </tbody>
+      </table>
+      <p style="margin-top: 16px; font-size: 16px;">Order total: <strong>${totalFormatted}</strong></p>
+      ${receiptLink}
+      <p style="margin-top: 24px;">We'll send another update when your kits ship.</p>
+    </div>
+  `;
+
+  const text = [
+    `Thank you for your order!`,
+    `Order ID: ${orderId}`,
+    `Order date: ${new Date(createdAt).toLocaleString()}`,
+    ...items.map((item) => `- ${item.quantity} x ${item.name ?? "Item"}`),
+    `Total: ${totalFormatted}`,
+    receiptUrl ? `Receipt: ${receiptUrl}` : "",
+  ].filter(Boolean).join("\n");
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: ORDER_FROM_EMAIL,
+      to: [to],
+      subject: "Your Logic Labs order confirmation",
+      html,
+      text,
+    }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    console.error("Failed to send confirmation email", message);
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20250901120000_add_stripe_fields_to_orders.sql
+++ b/supabase/migrations/20250901120000_add_stripe_fields_to_orders.sql
@@ -1,0 +1,9 @@
+-- Add Stripe tracking fields to orders table
+ALTER TABLE public.orders
+  ADD COLUMN IF NOT EXISTS stripe_session_id TEXT,
+  ADD COLUMN IF NOT EXISTS stripe_payment_intent_id TEXT,
+  ADD COLUMN IF NOT EXISTS receipt_url TEXT,
+  ADD COLUMN IF NOT EXISTS customer_email TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS orders_stripe_session_id_key
+  ON public.orders(stripe_session_id);


### PR DESCRIPTION
## Summary
- add a Stripe webhook Supabase function that persists checkout sessions as orders, clears carts, emails receipts, and links metadata back to Stripe
- expose a confirm-order edge function and refresh the payment success screen to fetch order details and clear the cart once the webhook finishes
- update checkout metadata, database types/migration, docs, and typings needed to support the new flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c86592e5a4832aaf402e0ff92b37b6